### PR TITLE
Stream public GitHub fetches as tarballs instead of full in-memory clones

### DIFF
--- a/arl/arl_test.go
+++ b/arl/arl_test.go
@@ -20,6 +20,7 @@
 package arl
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -110,11 +111,63 @@ func TestGithub(t *testing.T) {
 		t.Errorf("failed fetching github arl: %v", err)
 	} else {
 		nContents := 0
-		for range ch {
+		for c := range ch {
+			if c.Error != nil {
+				t.Errorf("unexpected error fetching github arl: %v", c.Error)
+			}
 			nContents += 1
 		}
-		if nContents < 50 || nContents > 100 {
+		if nContents < 100 || nContents > 1000 {
 			t.Errorf("unexpected number of resources: %d", nContents)
+		}
+	}
+}
+
+func TestGithubSubDir(t *testing.T) {
+	a, err := NewARL("[github,refractionPOINT/python-limacharlie/limacharlie]", 1024*1024*10, 10)
+	if err != nil {
+		t.Errorf("failed creating github arl: %v", err)
+	}
+
+	ch, err := a.Fetch()
+	if err != nil {
+		t.Errorf("failed fetching github arl: %v", err)
+	} else {
+		nContents := 0
+		for c := range ch {
+			if c.Error != nil {
+				t.Errorf("unexpected error fetching github arl: %v", c.Error)
+			}
+			if !strings.HasPrefix(c.FilePath, "limacharlie") {
+				t.Errorf("unexpected file outside of subdir: %s", c.FilePath)
+			}
+			nContents += 1
+		}
+		if nContents < 50 || nContents > 500 {
+			t.Errorf("unexpected number of resources: %d", nContents)
+		}
+	}
+}
+
+func TestGithubMaxSize(t *testing.T) {
+	// A tiny max size should abort the fetch with an error.
+	a, err := NewARL("[github,refractionPOINT/python-limacharlie]", 1024, 10)
+	if err != nil {
+		t.Errorf("failed creating github arl: %v", err)
+	}
+
+	ch, err := a.Fetch()
+	if err != nil {
+		t.Errorf("failed fetching github arl: %v", err)
+	} else {
+		isErrorSeen := false
+		for c := range ch {
+			if c.Error != nil {
+				isErrorSeen = true
+			}
+		}
+		if !isErrorSeen {
+			t.Error("max size exceeded but no error was produced")
 		}
 	}
 }

--- a/arl/github.go
+++ b/arl/github.go
@@ -20,9 +20,12 @@
 package arl
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -53,7 +56,7 @@ func (a AuthenticatedResourceLocator) getGitHub() (chan Content, error) {
 func (a AuthenticatedResourceLocator) getGitHubFromGit() (chan Content, error) {
 	// If the path in repo ends with "?ref=...", we extract the
 	// ref name we want to look for.
-	targetRef := plumbing.ReferenceName("")
+	targetBranch := ""
 	pathInRepo := ""
 	dest := a.methodDest
 	if strings.Contains(a.methodDest, "?ref=") {
@@ -62,7 +65,7 @@ func (a AuthenticatedResourceLocator) getGitHubFromGit() (chan Content, error) {
 			return nil, errors.New("invalid github path")
 		}
 		dest = components[0]
-		targetRef = plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", components[1]))
+		targetBranch = components[1]
 	}
 
 	// Get the repo name itself. It's the first 2 components.
@@ -75,19 +78,28 @@ func (a AuthenticatedResourceLocator) getGitHubFromGit() (chan Content, error) {
 		pathInRepo = strings.Join(components[2:], "/")
 	}
 
-	gitOptions := git.CloneOptions{
-		URL:           fmt.Sprintf("https://github.com/%s", repoPath),
-		ReferenceName: targetRef,
+	if a.authType == "" {
+		// Public repo: stream a tarball of the tree at HEAD instead of
+		// cloning, a clone materializes the full history in memory.
+		return a.getGitHubFromTarball(repoPath, pathInRepo, targetBranch)
 	}
 
-	if a.authType == "ssh" {
-		gitOptions.URL = fmt.Sprintf("git@github.com:%s", repoPath)
-		pubKey, err := ssh.NewPublicKeys("git", []byte(a.authData), "")
-		if err != nil {
-			return nil, fmt.Errorf("generate publickey failed: %v", err)
-		}
-		gitOptions.Auth = pubKey
+	gitOptions := git.CloneOptions{
+		URL: fmt.Sprintf("git@github.com:%s", repoPath),
+		// We only ever read the tree at the tip of one branch, a full
+		// clone would hold the entire history in memory.
+		Depth:        1,
+		SingleBranch: true,
 	}
+	if targetBranch != "" {
+		gitOptions.ReferenceName = plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", targetBranch))
+	}
+
+	pubKey, err := ssh.NewPublicKeys("git", []byte(a.authData), "")
+	if err != nil {
+		return nil, fmt.Errorf("generate publickey failed: %v", err)
+	}
+	gitOptions.Auth = pubKey
 
 	// Clone the repo in memory.
 	r, err := git.Clone(memory.NewStorage(), nil, &gitOptions)
@@ -117,15 +129,23 @@ func (a AuthenticatedResourceLocator) getGitHubFromGit() (chan Content, error) {
 	chOut := make(chan Content, a.maxConcurrent)
 	go func() {
 		defer close(chOut)
-		tree.Files().ForEach(func(f *object.File) error {
+		totalSize := uint64(0)
+		err := tree.Files().ForEach(func(f *object.File) error {
 			if !strings.HasPrefix(f.Name, pathInRepo) {
 				return nil
+			}
+			if a.maxSize != 0 {
+				totalSize += uint64(f.Size)
+				if totalSize > a.maxSize {
+					return fmt.Errorf("maximum resource size reached (%d bytes)", a.maxSize)
+				}
 			}
 			reader, err := f.Blob.Reader()
 			if err != nil {
 				return fmt.Errorf("failed to get blob reader: %v", err)
 			}
 			data, err := ioutil.ReadAll(reader)
+			reader.Close()
 			if err != nil {
 				return fmt.Errorf("failed to read blob: %v", err)
 			}
@@ -135,6 +155,98 @@ func (a AuthenticatedResourceLocator) getGitHubFromGit() (chan Content, error) {
 			}
 			return nil
 		})
+		if err != nil {
+			chOut <- Content{Error: err}
+		}
+	}()
+
+	return chOut, nil
+}
+
+// getGitHubFromTarball fetches the tree of a public GitHub repo at the tip of
+// a branch (or the default branch) as a streamed tarball. Unlike a git clone,
+// this holds at most one file in memory at a time and never fetches history.
+func (a AuthenticatedResourceLocator) getGitHubFromTarball(repoPath string, pathInRepo string, targetBranch string) (chan Content, error) {
+	ref := "HEAD"
+	if targetBranch != "" {
+		ref = fmt.Sprintf("refs/heads/%s", targetBranch)
+	}
+	url := fmt.Sprintf("https://codeload.github.com/%s/tar.gz/%s", repoPath, ref)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "AuthenticatedResourceLocator/Go")
+
+	client := a.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch repo tarball: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		resp.Body.Close()
+		return nil, fmt.Errorf("failed to fetch repo tarball %s: %s", url, resp.Status)
+	}
+
+	gzReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		resp.Body.Close()
+		return nil, fmt.Errorf("failed to read repo tarball: %v", err)
+	}
+
+	chOut := make(chan Content, a.maxConcurrent)
+	go func() {
+		defer close(chOut)
+		defer resp.Body.Close()
+		defer gzReader.Close()
+
+		totalSize := uint64(0)
+		tarReader := tar.NewReader(gzReader)
+		for {
+			header, err := tarReader.Next()
+			if err == io.EOF {
+				return
+			}
+			if err != nil {
+				chOut <- Content{Error: fmt.Errorf("failed to read repo tarball: %v", err)}
+				return
+			}
+			// We only care about regular files.
+			if header.Typeflag != tar.TypeReg {
+				continue
+			}
+			// GitHub tarballs prefix every entry with a top level
+			// "repoName-ref/" directory, strip it to get the path in repo.
+			name := header.Name
+			idx := strings.Index(name, "/")
+			if idx < 0 {
+				continue
+			}
+			name = name[idx+1:]
+			if name == "" || !strings.HasPrefix(name, pathInRepo) {
+				continue
+			}
+			if a.maxSize != 0 {
+				totalSize += uint64(header.Size)
+				if totalSize > a.maxSize {
+					chOut <- Content{Error: fmt.Errorf("maximum resource size reached (%d bytes)", a.maxSize)}
+					return
+				}
+			}
+			data, err := io.ReadAll(tarReader)
+			if err != nil {
+				chOut <- Content{FilePath: name, Error: fmt.Errorf("failed to read %s from repo tarball: %v", name, err)}
+				return
+			}
+			chOut <- Content{
+				FilePath: name,
+				Data:     data,
+			}
+		}
 	}()
 
 	return chOut, nil

--- a/arl/github.go
+++ b/arl/github.go
@@ -22,6 +22,7 @@ package arl
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,6 +31,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -163,6 +165,10 @@ func (a AuthenticatedResourceLocator) getGitHubFromGit() (chan Content, error) {
 	return chOut, nil
 }
 
+// tarballFetchTimeout bounds the life of a tarball transfer so that an
+// abandoned consumer cannot pin the underlying connection forever.
+const tarballFetchTimeout = 30 * time.Minute
+
 // getGitHubFromTarball fetches the tree of a public GitHub repo at the tip of
 // a branch (or the default branch) as a streamed tarball. Unlike a git clone,
 // this holds at most one file in memory at a time and never fetches history.
@@ -173,8 +179,10 @@ func (a AuthenticatedResourceLocator) getGitHubFromTarball(repoPath string, path
 	}
 	url := fmt.Sprintf("https://codeload.github.com/%s/tar.gz/%s", repoPath, ref)
 
-	req, err := http.NewRequest("GET", url, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), tarballFetchTimeout)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 	req.Header.Set("User-Agent", "AuthenticatedResourceLocator/Go")
@@ -185,22 +193,26 @@ func (a AuthenticatedResourceLocator) getGitHubFromTarball(repoPath string, path
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		cancel()
 		return nil, fmt.Errorf("failed to fetch repo tarball: %v", err)
 	}
 	if resp.StatusCode != 200 {
 		resp.Body.Close()
+		cancel()
 		return nil, fmt.Errorf("failed to fetch repo tarball %s: %s", url, resp.Status)
 	}
 
 	gzReader, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		resp.Body.Close()
+		cancel()
 		return nil, fmt.Errorf("failed to read repo tarball: %v", err)
 	}
 
 	chOut := make(chan Content, a.maxConcurrent)
 	go func() {
 		defer close(chOut)
+		defer cancel()
 		defer resp.Body.Close()
 		defer gzReader.Close()
 


### PR DESCRIPTION
## Problem

The unauthenticated GitHub ARL path (`getGitHubFromGit`) does a full in-memory git clone via `git.Clone(memory.NewStorage(), ...)` — full history, no shallow, no single-branch — even when the ARL points at a small subdirectory. `memory.NewStorage()` holds every object of every commit decompressed in RAM.

This is the root cause of the chronic OOM kills on `ext-yara-manager` (~350 over the last 7 days): its predefined rule sets include repos like `kevoreilly/CAPEv2` (~250MB packfile) and `Neo23x0/signature-base` (~42MB packfile), fetched per-org per-day with up to 8 syncs in flight per instance. Additionally, `maxSize` was only enforced on the token/API path — the git path had no size cap at all, so any org config pointing at a huge repo could OOM the shared service.

## Changes

- **Public repos**: fetch a streamed tarball of the tree at HEAD (or `?ref=` branch) from `codeload.github.com` instead of cloning. One file in memory at a time, no history, single unauthenticated HTTP request (no API rate-limit concerns).
- **ssh-auth repos**: keep go-git, but clone with `Depth: 1` + `SingleBranch: true`.
- **`maxSize` is now enforced** on both paths, cumulatively over the files actually returned (files outside the requested subdir don't count and are skipped while streaming). `0` still means unlimited.
- **Read errors are surfaced** on the `Content` channel; previously a blob read error silently truncated the result set.

## Verification

Same file sets and identical bytes returned as the old implementation for `python-limacharlie`, `CAPEv2/data/yara/CAPE`, `signature-base/yara`, `elastic/protections-artifacts/yara/rules`, and `Yara-Rules/rules/malware`.

Memory (fetching `Neo23x0/signature-base/yara`, 751 files / 7MB of content):

| | peak heap sys | total alloc |
|---|---|---|
| before | 1,522 MB | 4,000 MB |
| after | 22 MB | 38 MB |

All tests pass (`go test ./...`), including new coverage for subdir filtering and the size cap. The stale 50–100 file-count bound in `TestGithub` was updated — the fixture repo now has 249 files, so it would fail against the old code too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gbt47DLx2bn2inXHq1oX6d